### PR TITLE
check that children is not undefined and that it is not null instead of or

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ class Subscribe extends Component {
 
   setupSubscription() {
     const { children } = this.props;
-    if (children !== undefined || children !== null) {
+    if (children !== undefined && children !== null) {
       this.subscription = childrenToObservable(children).subscribe(element => {
         if (Array.isArray(element)) {
           throw new TypeError('<Subscribe> streams cannot return arrays because of React limitations');


### PR DESCRIPTION
right now if it is null it will always get inside of this if block since `null !== undefined`
